### PR TITLE
feat: Display base64 digest impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,45 +9,23 @@ jobs:
         feature_flags: ["no-default-features", "all-features"]
     runs-on: ubuntu-latest
     steps:
+    
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: rustfmt, clippy
-        override: true
 
     - name: fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
     - name: build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --${{matrix.feature_flags}} --verbose
+      run: cargo build --${{matrix.feature_flags}} --verbose
 
     - name: test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --${{matrix.feature_flags}} --lib --examples --tests --verbose
+      run: cargo test --${{matrix.feature_flags}} --lib --examples --tests --verbose
 
     - name: build benchmarks
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --${{matrix.feature_flags}} --benches --no-run --verbose
+      run: cargo test --${{matrix.feature_flags}} --benches --no-run --verbose
 
     - name: clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --${{matrix.feature_flags}}
+      run: cargo clippy --${{matrix.feature_flags}}
 
     - name: docs
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --${{matrix.feature_flags}} --document-private-items --no-deps
+      run: cargo doc --${{matrix.feature_flags}} --document-private-items --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 jobs:
   test:
+    strategy:
+      matrix:
+        feature_flags: ["no-default-features", "all-features"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -23,28 +26,28 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --verbose
+        args: --${{matrix.feature_flags}} --verbose
 
     - name: test
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all-features --lib --examples --tests --verbose
+        args: --${{matrix.feature_flags}} --lib --examples --tests --verbose
 
     - name: build benchmarks
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --benches --no-run --verbose
+        args: --${{matrix.feature_flags}} --benches --no-run --verbose
 
     - name: clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-features
+        args: --${{matrix.feature_flags}}
 
     - name: docs
       uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --document-private-items --no-deps
+        args: --${{matrix.feature_flags}} --document-private-items --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["data-structures", "cryptography"]
 
 [dependencies]
 siphasher = "0.3.10"
+base64 = { version = "0.21.2", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
@@ -20,6 +21,10 @@ criterion = "0.5.1"
 insta = "1.29.0"
 paste = "1.0.12"
 proptest = "1.2.0"
+
+[features]
+default = ["digest_base64"]
+digest_base64 = ["dep:base64"]
 
 [lib]
 bench = false

--- a/src/digest/trait.rs
+++ b/src/digest/trait.rs
@@ -50,6 +50,15 @@ impl<const N: usize> AsRef<[u8]> for Digest<N> {
     }
 }
 
+#[cfg(feature = "digest_base64")]
+impl<const N: usize> std::fmt::Display for Digest<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use base64::{display::Base64Display, engine::general_purpose::STANDARD};
+
+        Base64Display::new(&self.0, &STANDARD).fmt(f)
+    }
+}
+
 /// Extract the number of leading 0's when expressed as base 16 digits, defining
 /// the tree level the hash should reside at.
 pub(crate) fn level<const N: usize>(v: &Digest<N>) -> u8 {

--- a/src/digest/wrappers.rs
+++ b/src/digest/wrappers.rs
@@ -26,22 +26,10 @@ impl RootHash {
     }
 }
 
-/// Type wrapper over a [`Digest`] of a tree value, for readability / clarity /
-/// compile-time safety.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ValueDigest<const N: usize>(Digest<N>);
-
-impl<const N: usize> std::ops::Deref for ValueDigest<N> {
-    type Target = Digest<N>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<const N: usize> ValueDigest<N> {
-    pub(crate) const fn new(value: Digest<N>) -> Self {
-        Self(value)
+#[cfg(feature = "digest_base64")]
+impl std::fmt::Display for RootHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -63,5 +51,38 @@ impl std::ops::Deref for PageDigest {
 impl PageDigest {
     pub(crate) const fn new(value: Digest<16>) -> Self {
         Self(value)
+    }
+}
+
+#[cfg(feature = "digest_base64")]
+impl std::fmt::Display for PageDigest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Type wrapper over a [`Digest`] of a tree value, for readability / clarity /
+/// compile-time safety.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ValueDigest<const N: usize>(Digest<N>);
+
+impl<const N: usize> std::ops::Deref for ValueDigest<N> {
+    type Target = Digest<N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize> ValueDigest<N> {
+    pub(crate) const fn new(value: Digest<N>) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(feature = "digest_base64")]
+impl<const N: usize> std::fmt::Display for ValueDigest<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }


### PR DESCRIPTION
Add an optional feature to display digests as a bas64 string, and update CI to drive drive coverage of it enabled/disabled.

---

* feat: base64 hash Display impl (117f268)
      
      Optionally support rendering hash digests as base64 strings via a
      Display impl.

* ci: enumerate feature flags (125f8b4)
      
      Test with and without the code behind feature flags.

* ci: remove actions-rs (cbc6885)
      
      Uses deprecated options.